### PR TITLE
Feature/1week advanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,191 @@
+
+
+# 항해 1주차
+
+
+
+## 과제 목표
+- TDD 도입
+- 동시성 이슈 해결
+  - 동시성 이슈: 여러 요청이 동시에 들어오는 상황에서 Race Condition(경쟁 조건) 상태
+
+
+
+
+## 심화 과제 목표
+
+- 선택한 언어에 대한 동시성 제어 방식 및 각 적용의 장/단점을 기술한 보고서 작성
+
+
+
+
+### Kotlin, Java 언어에서의 동시성 이슈 해결
+- Synchronized, ConcurrentHashMap, ReentrantLock
+
+
+
+#### @Synchronized (현재 적용된 방식)
+
+```kotlin
+@Synchronized
+override fun insertOrUpdate(id: Long, amount: Long): UserPoint {
+    val current = selectById(id)
+    return userPointTable.insertOrUpdate(id, current.point + amount)
+}
+```
+
+장점:
+
+- 구현이 간단
+
+- 데드락 위험이 적음
+
+- 모든 동기화 문제를 확실히 해결
+
+단점:
+
+- 성능 저하 (한 번에 하나의 스레드만 접근)
+
+- 분산 환경에서 사용 불가
+
+- 메모리 사용량 증가
+
+
+
+#### ReentrantLock
+
+```kotlin
+private val lock = ReentrantLock()
+
+fun updatePoint(id: Long, amount: Long): UserPoint {
+    lock.lock()
+    try {
+        val current = selectById(id)
+        return userPointTable.insertOrUpdate(id, current.point + amount)
+    } finally {
+        lock.unlock()
+    }
+}
+```
+
+장점:
+
+- 더 세밀한 제어 가능
+
+- tryLock() 으로 타임아웃 설정 가능
+
+- 인터럽트 처리 가능
+
+단점:
+
+- 구현이 복잡
+
+- 실수로 lock 해제를 놓칠 수 있음
+
+- 분산 환경에서 사용 불가
+
+
+
+#### ConcurrentHashMapkotlin
+
+```kotlin
+private val pointMap = ConcurrentHashMap<Long, AtomicLong>()
+
+fun updatePoint(id: Long, amount: Long): UserPoint {
+    val point = pointMap.computeIfAbsent(id) { AtomicLong(0) }
+    point.addAndGet(amount)
+    return UserPoint(id, point.get(), System.currentTimeMillis())
+}
+```
+
+장점:
+
+- 세밀한 동시성 제어
+
+- 높은 성능
+
+- 부분 잠금으로 인한 처리량 향상
+
+단점:
+
+- 복잡한 연산에는 부적합
+- 메모리 사용량 증가
+- 분산 환경에서 사용 불가
+
+
+
+### 인프라 관점에서의 해결
+- DB lock 사용
+- Redis 사용
+
+
+
+#### DB Lock
+
+```sql
+SELECT point FROM user_point WHERE id = ? FOR UPDATE
+```
+
+
+
+장점:
+
+- 데이터 정합성 보장
+
+- 분산 환경에서 사용 가능
+
+- 트랜잭션 관리 용이
+
+단점:
+
+- 성능 저하
+
+- 데드락 가능성
+
+- Lock 범위가 커질 수 있음
+
+
+
+#### Redis 기반 분산 락
+
+```kotlin
+val lock = redisTemplate.opsForValue()
+if (lock.setIfAbsent(key, value, Duration.ofSeconds(3))) {
+    try {
+        // 포인트 업데이트 로직
+    } finally {
+        lock.delete(key)
+    }
+}
+```
+
+장점:
+
+- 분산 환경에서 사용 가능
+
+- 높은 성능
+
+- 세밀한 락 제어 가능
+
+단점:
+
+- 추가 인프라 필요
+
+- 구현이 복잡
+
+- 네트워크 지연 영향
+
+
+
+
+
+## 과제 중 기타 사항
+
+
+
+
+### 과제 해결 중 현재 구조적으로 문제해야할 할일
+
+- 현재 DAO와 DTO가 섞여있어서, 도메인 모델의 비즈니스 로직과 엔티티 모델에 필요한 로직이 통합되어있다-> 책임분리 필요
+- 현재 Controller에서 DTO를 그대로 반환하는 중이다. 이는 추후 응답값이 달라져야할때, 도메인 모델까지 영향을 줄수있으므로 필요시 분리 필요
+- 현재 폴더 트리 구조는 hhplus.tdd.[database, point, Application.kt]이다. 도메인별로 분리되었지만, point.[Controller, Service, UserPoint. ...]등이 패키지 구조없이 존재한다 -> 패키지 분리 필요

--- a/src/main/kotlin/io/hhplus/tdd/point/service/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/service/PointService.kt
@@ -22,6 +22,7 @@ class PointService(
         return pointHistoryRepository.selectAllByUserId(id)
     }
 
+    @Synchronized
     override fun chargePoint(request: ChargePointRequest): UserPoint {
         val userPoint = userPointRepository.selectById(request.userId)
         val chargedPoint = userPoint.chargePoint(request.amount)
@@ -38,6 +39,7 @@ class PointService(
         return savedUserPoint
     }
 
+    @Synchronized
     override fun usePoint(request: UsePointRequest): UserPoint {
         val userPoint = userPointRepository.selectById(request.userId)
         val chargedPoint = userPoint.usePoint(request.amount)

--- a/src/test/kotlin/io/hhplus/tdd/point/service/PointServiceIntegrationTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/point/service/PointServiceIntegrationTest.kt
@@ -1,0 +1,277 @@
+package io.hhplus.tdd.point.service
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.exceptions.PointAmountNegativeException
+import io.hhplus.tdd.point.service.dto.dao.TransactionType
+import io.hhplus.tdd.point.service.dto.request.ChargePointRequest
+import io.hhplus.tdd.point.service.dto.request.UsePointRequest
+import io.hhplus.tdd.support.utils.DateUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+// TODO : 통합테스트 시에, 매번 테스트 시 빈 초기화가 필요하다. userPointTable, pointHistoryTable를 비울수있는 함수가없다. -> 어떻게 해야할까? -> 현재는 userId를 테스트마다 유일하게 한다.
+//  현재 조건에서 -> 다른 좋은 방법은?
+@SpringBootTest
+class PointServiceIntegrationTest {
+
+    private val validUserId = 1L
+    private val validAmount = 1000L
+
+    @Autowired
+    private lateinit var pointService: PointService
+
+    @Autowired
+    private lateinit var userPointTable: UserPointTable
+
+    @Autowired
+    private lateinit var pointHistoryTable: PointHistoryTable
+
+    @BeforeEach
+    fun setUp() {
+        //initValidUserPoint = 0
+        userPointTable.insertOrUpdate(validUserId, 0L)
+    }
+
+    // TODO : 간단한 성공 통합테스트 정도는 필요한가?
+    @Test
+    fun `getUserPointInfo - 유저의 현재 포인트 조회 성공`() {
+        // given
+        userPointTable.insertOrUpdate(validUserId, validAmount)
+
+        //when
+        pointService.getUserPointInfo(validUserId)
+
+        //then
+        val result = userPointTable.selectById(validUserId)
+
+        assertEquals(validUserId, result.id)
+        assertEquals(validAmount, result.point)
+    }
+
+    // TODO : 간단한 성공 통합테스트 정도는 필요한가?
+    @Test
+    fun `getUserPointHistories - 유저의 현재 포인트 이력 리스트 조회 성공`() {
+        // given
+
+        val expectedAmount = 9999999L
+        pointHistoryTable.insert(
+            validUserId,
+            expectedAmount,
+            TransactionType.CHARGE,
+            DateUtils.nowDateTimeByMilli()
+        )
+
+        // when
+        val resultList = pointService.getUserPointHistories(validUserId)
+
+        // then
+        assertTrue(resultList.any { history ->
+            history.userId == validUserId &&
+                    history.amount == expectedAmount &&
+                    history.type == TransactionType.CHARGE
+        })
+    }
+
+
+    @Test
+    fun `chargePoint - 100개의 동시 1000L 포인트 충전 요청 후 100000L 포인트 조회 성공`() {
+        // given
+        val testUserId = validUserId + 1
+
+        val request = ChargePointRequest(testUserId, validAmount)
+        val threadCount = 100
+        val executorService = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val expectedTotalAmount = validAmount * threadCount
+
+        // when - 100개의 스레드에서 동시에 포인트 충전 요청
+        repeat(threadCount) {
+            executorService.submit {
+                try {
+                    pointService.chargePoint(request)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        // 모든 요청이 완료될 때까지 대기
+        latch.await(1000, TimeUnit.SECONDS)
+        executorService.shutdown()
+
+        // then - 최종 포인트 잔액 확인
+        val finalPoint = pointService.getUserPointInfo(testUserId)
+        assertEquals(expectedTotalAmount, finalPoint.point)
+
+
+    }
+
+    @Test
+    fun `usePoint - 1000L 포인트에서 100개의 동시 1L 포인트 사용 요청 시 결과 900L포인트 조회 성공`() {
+        // given - 포인트 사용 요청 및 차감된 포인트 DB 응답 설정
+        val testUserId = validUserId + 2
+        val chargePointRequest = ChargePointRequest(testUserId, validAmount)
+        pointService.chargePoint(chargePointRequest)
+
+        val USE_POINT = 1L
+
+        val threadCount = 100
+        val executorService = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val expectedTotalAmount = validAmount - USE_POINT * threadCount
+
+
+        // when - 100개의 스레드에서 동시에 포인트 사용 요청
+        val usePointRequest = UsePointRequest(testUserId, USE_POINT)
+
+        repeat(threadCount) {
+            executorService.submit {
+                try {
+                    pointService.usePoint(usePointRequest)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        // 모든 요청이 완료될 때까지 대기
+        latch.await(1000, TimeUnit.SECONDS)
+        executorService.shutdown()
+
+        // then - 최종 포인트 잔액 확인
+        val finalPoint = pointService.getUserPointInfo(testUserId)
+        assertEquals(expectedTotalAmount, finalPoint.point)
+
+        // then - 최종 충전 히스토리 확인
+        val userPointHistories = pointService.getUserPointHistories(testUserId)
+        assertEquals(threadCount + 1, userPointHistories.size)
+
+    }
+
+    @Test
+    // TODO : 통합테스트 중에 given 설정시 pointService.chargePoint()메서드를 사용했는데, 통합테스트 대상을 given에 사용해도되나?
+    fun `usePoint - 1000L 포인트에서 100개의 동시 100L 포인트 사용 요청 시 결과 10개의 요청 처리 성공 및 90개의 요청은 PointAmountNegativeException 실패 확인`() {
+        // given
+        val testUserId = validUserId + 3
+
+        val chargePointRequest = ChargePointRequest(testUserId, validAmount)
+        pointService.chargePoint(chargePointRequest)
+
+        val USE_POINT = 100L
+        val threadCount = 100
+        val executorService = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+
+        // 성공/실패 카운터
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        val usePointRequest = UsePointRequest(testUserId, USE_POINT)
+
+        repeat(threadCount) {
+            executorService.submit {
+                try {
+                    pointService.usePoint(usePointRequest)
+                    successCount.incrementAndGet()
+                } catch (e: PointAmountNegativeException) {
+                    failCount.incrementAndGet()
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        // 모든 요청이 완료될 때까지 대기
+        latch.await(10, TimeUnit.SECONDS)
+        executorService.shutdown()
+
+        // then
+        val finalPoint = pointService.getUserPointInfo(testUserId)
+
+        // 성공/실패 횟수 검증
+        assertEquals(10, successCount.get(), "성공한 요청 수가 10개여야 합니다")
+        assertEquals(90, failCount.get(), "실패한 요청 수가 90개여야 합니다")
+
+        // 최종 포인트 잔액 확인 (1000 - (100 * 10) = 0)
+        assertEquals(0, finalPoint.point)
+
+        // then - 최종  히스토리 확인
+        val userPointHistories = pointService.getUserPointHistories(testUserId)
+        assertEquals(10 + 1, userPointHistories.size)
+    }
+
+    @Test
+    fun `chargePoint + usePoint - 1000L 포인트에서 100개의 동시 1000L 포인트 충전 요청 + 100개의 동시 10L 포인트 사용 요청 및 100000+1000-1000 결과 조회 성공`() {
+        // given
+        val testUserId = validUserId + 4
+
+        val charge = ChargePointRequest(testUserId, validAmount)
+        pointService.chargePoint(charge)
+
+        val CHARGE_POINT = 1000L
+        val USE_POINT = 10L
+        val threadCount = 200
+        val executorService = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+
+        // 성공/실패 카운터
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        val usePointRequest = UsePointRequest(testUserId, USE_POINT)
+        val chargePointRequest = ChargePointRequest(testUserId, CHARGE_POINT)
+
+        repeat(100) {
+            executorService.submit {
+                try {
+                    pointService.usePoint(usePointRequest)
+                    successCount.incrementAndGet()
+                } catch (e: PointAmountNegativeException) {
+                    failCount.incrementAndGet()
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+        repeat(100) {
+            executorService.submit {
+                try {
+                    pointService.chargePoint(chargePointRequest)
+                    successCount.incrementAndGet()
+                } catch (e: PointAmountNegativeException) {
+                    failCount.incrementAndGet()
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        // 모든 요청이 완료될 때까지 대기
+        latch.await(10, TimeUnit.SECONDS)
+        executorService.shutdown()
+
+        // then
+        val finalPoint = pointService.getUserPointInfo(testUserId)
+
+        // 성공/실패 횟수 검증
+
+        // 최종 포인트 잔액 확인 100000+1000-1000
+        assertEquals(100000, finalPoint.point)
+        // then - 최종  히스토리 확인
+        val userPointHistories = pointService.getUserPointHistories(testUserId)
+        assertEquals(100 + 100 + 1, userPointHistories.size)
+
+    }
+
+} 


### PR DESCRIPTION
### **커밋 링크**
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


동시성 처리 : [커밋](https://github.com/lostcatbox/hhplus-tdd/pull/5/commits/b8e9a773d24dfd9e7f8f6f891ee92b1c12a22f23)
동시성 테스트 코드 : [커밋](https://github.com/lostcatbox/hhplus-tdd/pull/5/commits/4cd73da0007d412d22aebff36be3109f33714a24)


---
### **리뷰 포인트(질문)**
- [리뷰 포인트 1](https://github.com/lostcatbox/hhplus-tdd/pull/5/commits/4cd73da0007d412d22aebff36be3109f33714a24#diff-2ed396ddde2c57e7199f18299999d282e2e9d6e3f49dad58d54294370d43389bR161-R162) : pointService 관련 통합테스트 중에 given 설정시 pointService.chargePoint()메서드를 사용했는데, 통합테스트 대상을 given에 사용해도되나?
- [리뷰 포인트 2](https://github.com/lostcatbox/hhplus-tdd/pull/5/commits/4cd73da0007d412d22aebff36be3109f33714a24#diff-2ed396ddde2c57e7199f18299999d282e2e9d6e3f49dad58d54294370d43389bR21) :  테스트시에는 모든 테스트가 순서와 상관없이 서로 영향을 주면 안되고 독립적인 테스트여야한다고 생각한다. 그래서 현재 통합테스트 시에, 현 상황에서  userPointTable, pointHistoryTable를 비울수있는 함수가없다. -> 어떻게 해야할까? -> 현재는 userId를 테스트마다 유일하게 한다.

### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 객체 지향적 사고
### Problem
<!--개선이 필요한 점-->
- 동시성 제어 방식별로 테스트 하고싶었음..시간부족
### Try
- 동시성 제어 방식별로 테스트 
